### PR TITLE
Remove Outdated Instructions

### DIFF
--- a/Page/en/Manual/Building tracks.mediawiki
+++ b/Page/en/Manual/Building tracks.mediawiki
@@ -14,24 +14,6 @@ Besides laying tracks on flat land you can also [[en/Archive/Manual/Settings/Bui
 * Using 4 directioned track buttons (easy & quite slow)
 * Using Autorail tool (fast but less easy)
 
-== Building selected direction tracks ==
-
-Click on one of the rail building buttons ( [[File:en/Manual/Build rail.png]] ). The example uses the 4th button.
-
-=== Placing tracks ===
-#Move the cursor over the tile you want to start your track on.<br/>[[File:en/Manual/Laying track 1.png|none|frame|Laying a new track]]
-#Drag the cursor to where you want your track to end.<br/>[[File:en/Manual/Laying track 2.png|none|frame|Laying a new track]]
-#Release the mouse button and your new track will appear.<br/>[[File:en/Manual/Laying track 3.png|none|frame|Your new track]]
-
-=== Removing tracks === 
-To remove the tracks, '''select the Remove tool''' ( [[File:en/Manual/Toggle clear active.png|Clear button]] ). The white square will change to a red square. Now you can simply '''click & drag''' along the existing tracks to remove them. Click the tool button again to deselect it. You can also use the  '''R''' key shortcut to toggle Remove. For rails only, holding '''Ctrl''' key activates removal.
-
-== Using Autorail tool ==
-''For more information, check [[en/Archive/Manual/Autorail]]''
-
-First '''select the Autorail''' button ( [[File:en/Manual/Build autorail.png|Autorail button]] ) from the railway construction toolbar. You cursor will change to represent Autorail feature. The shortcut for this is '''A'''.
-[[File:en/Manual/AutorailTut1.png|none|frame|Selecting Autorail feature]]
-
 === Placing tracks ===
 #Placing horizontal/vertical straight pieces (along squares) is the easiest. Put your cursor over any square and '''click & drag''' along the squares. The white lines represent your future tracks.<br/>You can click in a square and move your mouse in different directions to see how new tracks would be placed.<br/>[[File:en/Manual/AutorailTut2.png|none|frame|Laying a straight piece of tracks]]
 #Release your mouse cursor and you will have built a straight piece of tracks.<br/>[[File:en/Manual/AutorailTut3.png|none|frame|A newly built straight piece of tracks]]
@@ -41,6 +23,7 @@ First '''select the Autorail''' button ( [[File:en/Manual/Build autorail.png|Aut
 | [[File:en/Manual/AutorailTut5.png|none|frame|Laying a piece of tracks over a hilly terrain]]
 | [[File:en/Manual/AutorailTut6.png|none|frame|Laid a piece of tracks over hills]]
 |}
+
 === Removing tracks ===
 There are two ways to remove pieces of tracks (besides the dynamite ( [[File:en/Manual/Clear title.png|Dynamite tool]] ) tool)
 


### PR DESCRIPTION
For some reason the Building Tracks page has two sets of instructions. This patch removes the ones that appear to be outdated