### PR TITLE
Update Installation.mediawiki

### DIFF
--- a/Page/en/Manual/Installation.mediawiki
+++ b/Page/en/Manual/Installation.mediawiki
@@ -112,7 +112,7 @@ The following files are mandatory. You need to copy them to the /baseset directo
 * sample.cat
 
 
-Additionally, you may want to copy the original game music. To accomplish that, you need to copy the /gm/ folder from the TTD CD to the /baseset in your personal OpenTTD directory.
+Additionally, you may want to copy the original game music. To accomplish that, you need to copy the /gm/ folder from the TTD CD to your personal OpenTTD directory.
 
 
 There are a few ways to get these files:


### PR DESCRIPTION
`/gm/` directory shouldn't be within `baseset/` for OpenTTD to recognize original music files