### PR TITLE
Fix: [Actions] make the Reload command work with AWS CLIv2

### DIFF
--- a/.github/workflows/reload.yaml
+++ b/.github/workflows/reload.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Reload wiki
       run: |
-        aws lambda invoke --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.RELOAD_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.RELOAD_SECRET }}"}' output.txt
+        aws lambda invoke --cli-binary-format raw-in-base64-out --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.RELOAD_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.RELOAD_SECRET }}"}' output.txt
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
AWS CLIv2 needs telling the payload is raw, instead of a base64 encoded blob.

This is already running on staging: https://github.com/OpenTTD/wiki-data-staging/runs/2649497343?check_suite_focus=true