### PR TITLE
Add: prepare for TrueWiki 1.3, which contains better mobile support

### DIFF
--- a/static/css/openttd.css
+++ b/static/css/openttd.css
@@ -60,18 +60,35 @@ body > header {
 
 #openttd-logo {
 	background: url("../img/layout/openttd-64.gif") no-repeat left bottom 2px;
-	height: 68px;
-	width: 250px;
+	background-size: 48px;
+	height: 50px;
+	width: 180px;
 	position: relative;
 }
 #openttd-logo-text,
 #openttd-logo-text img {
 	display: block;
 }
+#openttd-logo-text img {
+	width: 121px;
+}
 #openttd-logo-text {
 	position: absolute;
 	bottom: 4px;
-	left: 78px;
+	left: 58px;
+}
+@media only screen and (min-width: 1020px) {
+	#openttd-logo {
+		background-size: auto;
+		height: 68px;
+		width: 250px;
+	}
+	#openttd-logo-text {
+		left: 78px;
+	}
+	#openttd-logo-text img {
+		width: 100%;
+	}
 }
 
 #hr-clear {
@@ -88,4 +105,9 @@ body > header {
 
 #review-access {
     top: 70px;
+}
+
+#search {
+	left: 405px;
+	top: -105px;
 }


### PR DESCRIPTION
Includes #11. Will rebase after that one is merged

---

- Move the search bar back to its correct place
- Scale the logo to a smaller format when having smaller viewports
 
This change is already live on https://wiki.staging.openttd.org/
