### PR TITLE
Change: Link OpenTTD logo to the main OpenTTD website

### DIFF
--- a/.truewiki.yml
+++ b/.truewiki.yml
@@ -9,7 +9,7 @@ license:
 html-snippets:
   header: |
     <div id="openttd-logo">
-        <div id="openttd-logo-text"><a href="/en/"><img src="/static/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
+        <div id="openttd-logo-text"><a href="https://www.openttd.org/"><img src="/static/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
     </div>
   footer: |
     <a href="https://www.openttd.org/policy.html">Privacy Policy</a> |


### PR DESCRIPTION
This builds upon the change in PR https://github.com/OpenTTD/website/pull/350, making jumping from the wiki back to the main site easier and more intuitive.