### PR TITLE
Change: Make the OpenTTD logo a hyperlink

### DIFF
--- a/.truewiki.yml
+++ b/.truewiki.yml
@@ -8,9 +8,9 @@ license:
   GNU Free Documentation License
 html-snippets:
   header: |
-    <div id="openttd-logo">
-        <div id="openttd-logo-text"><a href="/en/"><img src="/static/img/layout/openttd-logo.png" alt="OpenTTD" /></a></div>
-    </div>
+    <a id="openttd-logo" href="/en/">
+        <div id="openttd-logo-text"><img src="/static/img/layout/openttd-logo.png" alt="OpenTTD" /></div>
+    </a>
   footer: |
     <a href="https://www.openttd.org/policy.html">Privacy Policy</a> |
     <a href="https://www.openttd.org/contact.html">Contact</a> |


### PR DESCRIPTION
This will match the functionality found on the main site.